### PR TITLE
[FIX] Button not appearing in post admin menu due to core changes

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-reset-bump.js.es6
+++ b/assets/javascripts/discourse/initializers/discourse-reset-bump.js.es6
@@ -55,6 +55,25 @@ function resetBumpButtonDecorateCallback(dec) {
 	return dec.attach('post-admin-menu-button', buttonAttr);
 }
 
+function newApiInitCallback(api)
+{
+	api.addPostAdminMenuButton((name, attrs) => {
+		return {
+			action: (post) => {
+				const ajaxParams = {
+					type: 'POST',
+					data: { post_id: post.id }
+				};
+
+				ajax("/reset_bump", ajaxParams).catch(popupAjaxError);
+			},
+			icon: 'calendar-times',
+			className: 'reset-bump',
+			label: 'reset_bump.button_label',
+		};
+	});
+}
+
 function apiInitCallback(api)
 {
 	// If the plugin is disabled, do nothing.
@@ -63,7 +82,7 @@ function apiInitCallback(api)
 	// That's normal and fine; the ability to disable plugins is really just there in case
 	// they start causing problems and need to be quickly turned off without a server restart.
 	const siteSettings = api.container.lookup('site-settings:main');
-	
+
 	if (!siteSettings.reset_bump_enabled) {
 		return;
 	}
@@ -75,6 +94,12 @@ function apiInitCallback(api)
 	const currentUser = api.getCurrentUser();
 
 	if (!currentUser || !currentUser.staff) {
+		return;
+	}
+
+	// Since API v1.12, api.addPostAdminMenuButton() is the new way to add a button.
+	if (api.addPostAdminMenuButton) {
+		newApiInitCallback(api);
 		return;
 	}
 
@@ -122,7 +147,7 @@ export default {
 		// We pass withPluginApi our callback function, which is given the api object to set things up.
 		// Our callback may not be called at all if the version we are requesting becomes unsupported.
 		// See: https://meta.discourse.org/t/a-new-versioned-api-for-client-side-plugins/40051
-		// See: https://github.com/discourse/discourse/blob/master/app/assets/javascripts/discourse/lib/plugin-api.js.es6
+		// See: https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/lib/plugin-api.js
 		withPluginApi('0.7', apiInitCallback);
 	}
 };


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/a-way-to-de-bump-or-reset-bump-a-topic/281866.

Due to recent core changes, the [post-admin-menu](https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/widgets/post-admin-menu.js) widget has been “removed” recently in favor of a glimmer component here [admin-post-menu.gjs](https://github.com/discourse/discourse/blob/main/app/assets/javascripts/discourse/app/components/admin-post-menu.gjs).

I made changes to improve review and compatibility while keeping the old code (the comments are really cool).
Let me know if it's acceptable for you!

Tested on:

![chrome_LWrOdobfHa](https://github.com/LeoDavidson/discourse-reset-bump/assets/360640/3b2c2f5f-9ea5-4352-8c96-eda55356794d)

![image](https://github.com/LeoDavidson/discourse-reset-bump/assets/360640/656a52db-7ad3-414f-ae16-29088d7fa084)
